### PR TITLE
feat: add lint to ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run lint && NODE_ENV=test c8 mocha",
-    "test:ci": "NODE_ENV=test mocha",
-    "lint": "standardx --fix",
+    "test:ci": "npm run lint && NODE_ENV=test mocha",
+    "lint": "standardx --fix --verbose",
     "release": "release-it --config release-it/config.js"
   },
   "repository": {
@@ -58,6 +58,6 @@
     ]
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 14.17.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,16 @@
 const { chai, expect, sinon } = require('../')
 
+// This class only exists to be parsed by standardx
+// and ensure Babel is being used.
+class Dummy {
+  test ({ value1, value2 = 2, value3 = null, value4 = {} }) {
+    this.v1 = value1
+    this.v2 = value2
+    this.v3 = value3
+    this.v4 = value4?.value5?.value6
+  }
+}
+
 describe('main require', function () {
   it('exports chai', function () {
     expect(chai).to.exist
@@ -7,5 +18,16 @@ describe('main require', function () {
 
   it('exports sinon', function () {
     expect(sinon).to.exist
+  })
+
+  // This test only exists so standardx doesn't
+  // complain that the Dummy class isn't used.
+  it('parses code', function () {
+    var dummy = new Dummy()
+    dummy.test({ value1: 1, value2: 'not2', value3: 3, value4: { value5: { value6: 4 } } })
+    expect(dummy.v1).to.eq(1)
+    expect(dummy.v2).to.eq('not2')
+    expect(dummy.v3).to.eq(3)
+    expect(dummy.v4).to.eq(4)
   })
 })


### PR DESCRIPTION
Running linting during CI to ensure babel works (standardx uses babel).

Also pinning Node version.

Closes #8.
Closes #9.